### PR TITLE
Extending modules for using Shiny modules

### DIFF
--- a/app.R
+++ b/app.R
@@ -4,16 +4,16 @@ shiny_component_tab_1 <- source("components/01_tab_1.R")$value
 shiny_component_tab_2 <- source("components/02_tab_2.R")$value
 shiny_component_tab_3 <- source("components/03_tab_3.R")$value
 
-use <- function(file) {
-  ## - custom definition of modules::use to circumvent base::library
-  ## - use with care
-  ## - still throws a warning, which is expected
-  e <- new.env(parent = baseenv())
-  e$library <- modules::import
-  modules::as.module(file, topEncl = e)
-}
-
-m <- use("modules/lag")
+# use <- function(file) {
+#   ## - custom definition of modules::use to circumvent base::library
+#   ## - use with care
+#   ## - still throws a warning, which is expected
+#   e <- new.env(parent = baseenv())
+#   e$library <- modules::import
+#   modules::as.module(file, topEncl = e)
+# }
+# 
+# m <- use("modules/lag/lag.R")
 
 shinyApp(
   # ................................. #
@@ -42,7 +42,7 @@ shinyApp(
     # Server logic for toc menuItem (03_tab_3.R)
     shiny_component_tab_3$server(input, output, session)
     
-    # To reset the lag example
+    # To reset the lag example on app refresh (session and restart)
     onSessionEnded(function() { 
       if ("dplyr" %in% .packages()) {
         detach(name = "package:dplyr", unload = TRUE)
@@ -52,6 +52,12 @@ shinyApp(
     onStop(function() { 
       if ("dplyr" %in% .packages()) {
         detach(name = "package:dplyr", unload = TRUE)
+      }
+      if(exists("lagUI")) {
+        rm(lagUI,envir = .GlobalEnv)
+      }
+      if(exists("lagSERVER")) {
+        rm(lagSERVER,envir = .GlobalEnv)
       }
     })
   }

--- a/app.R
+++ b/app.R
@@ -4,16 +4,6 @@ shiny_component_tab_1 <- source("components/01_tab_1.R")$value
 shiny_component_tab_2 <- source("components/02_tab_2.R")$value
 shiny_component_tab_3 <- source("components/03_tab_3.R")$value
 
-# use <- function(file) {
-#   ## - custom definition of modules::use to circumvent base::library
-#   ## - use with care
-#   ## - still throws a warning, which is expected
-#   e <- new.env(parent = baseenv())
-#   e$library <- modules::import
-#   modules::as.module(file, topEncl = e)
-# }
-# 
-# m <- use("modules/lag/lag.R")
 
 shinyApp(
   # ................................. #

--- a/components/01_tab_1.R
+++ b/components/01_tab_1.R
@@ -26,7 +26,13 @@ list(
           ),
           p(
             "Loading Shiny module via library(modules) module prevents such error"
-          )
+          ),
+          p(
+            "'Mimick' referes to when libarry(modules) is used on R script that does not follow library(modules) syntax"
+          ),
+          hr(),
+          p("Please carefully read the buttont and message texts. Different use of the word 'module' can be very confusing!")
+          
         )
       )
     ),

--- a/components/03_tab_3.R
+++ b/components/03_tab_3.R
@@ -5,70 +5,76 @@ list(
       tabName = "tab_3",
       fluidRow(
         box(
-          title = "Without Shiny modules",
-          width = 12,
-          fluidRow(
-            column(
-              width = 4,
-              h4("Example of using lag function from library(stats)"),
-              actionButton("tab-3-stats-lag-func", label = "stats::lag(1:5)"),
-              verbatimTextOutput("tab-3-stats-lag-res")
+          width = 4, height = 345,
+          h5("Output: lag function from library(stats)"),
+          actionButton("tab-3-stats-lag-func", label = "stats::lag(1:5)"),
+          verbatimTextOutput("tab-3-stats-lag-res")
+        ),
+        box(
+          width = 4, height = 345,
+          h5("Using lag function without Shiny modules"),
+          actionButton("tab-3-lag-func", label = "lag(1:5)"),
+          verbatimTextOutput("tab-3-lag-res")
+        ),
+        box(
+          width = 4, height = 345,
+          h5("Using library(modules) with correct syntax"),
+          tabsetPanel(
+            tabPanel(
+              "stats",
+              p("using 'library_modules_lab_stats.R'"),
+              p("Desired output: statslag(1:5)"),
+              uiOutput("tab-3-modules-stats-lag-ui")
             ),
-            column(
-              width = 4,
-              h4("Example of using lag function without specifying"),
-              actionButton("tab-3-lag-func", label = "lag(1:5)"),
-              verbatimTextOutput("tab-3-lag-res")
-            ),
-            column(
-              width = 4,
-              h4("Example of using lag function from Shiny module 'lag'"),
-              tabsetPanel(
-                tabPanel(
-                  "Shiny modules 'stats'",
-                  p("Example of using library(stats) lag function from 'lag_stats.R'"),
-                  p("Desired output: stats::lag(1:5)"),
-                  uiOutput("tab-3-shiny-module-stats-lag-ui")
-                ),
-                tabPanel(
-                  "Shiny modules 'dplyr'",
-                  p("Example of using library(dplyr) lag funciton from 'lag_dplyr.R'"),
-                  p("Desired output: dplyr::lag(1:5)"),
-                  uiOutput("tab-3-shiny-module-dplyr-lag-ui")
-                )
-              )
-              
+            tabPanel(
+              "dplyr",
+              p("using 'library_modules_lab_dplyr.R'"),
+              p("Desired output: dplyr::lag(1:5)"),
+              uiOutput("tab-3-modules-dplyr-lag-ui")
             )
-          ),
-          fluidRow(
-            column(
-              width = 4,
-              h4("Example of using lag function from library(dplyr)"),
-              actionButton("tab-3-dplyr-lag-func", label = "dplyr::lag(1:5)"),
-              verbatimTextOutput("tab-3-dplyr-lag-res")
+          )
+        )
+      ),
+      fluidRow(
+        box(
+          width = 4, height = 345,
+          h5("outout: lag function from library(dplyr)"),
+          actionButton("tab-3-dplyr-lag-func", label = "dplyr::lag(1:5)"),
+          verbatimTextOutput("tab-3-dplyr-lag-res")
+        ),
+        box(
+          width = 4, height = 345,
+          h5("Using lag function from Shiny module"),
+          tabsetPanel(
+            tabPanel(
+              "stats",
+              p("using 'lag_stats.R'"),
+              p("Desired output: stats::lag(1:5)"),
+              uiOutput("tab-3-shiny-module-stats-lag-ui")
             ),
-            column(
-              width = 4,
-              h4("Example of using lag function without specifying (copy)"),
-              actionButton("tab-3-lag-copy-func", label = "lag(1:5)"),
-              verbatimTextOutput("tab-3-lag-copy-res")
+            tabPanel(
+              "dplyr",
+              p("using 'lag_dplyr.R'"),
+              p("Desired output: dplyr::lag(1:5)"),
+              uiOutput("tab-3-shiny-module-dplyr-lag-ui")
+            )
+          )
+        ),
+        box(
+          width = 4, height = 345,
+          h5("Using Shiny modules while mimicking library(modules)"),
+          tabsetPanel(
+            tabPanel(
+              "stats",
+              p("using 'lag_stats.R'"),
+              p("Desired output: stats::lag(1:5)"),
+              uiOutput("tab-3-mimick-modules-stats-lag-ui")
             ),
-            column(
-              width = 4,
-              tabsetPanel(
-                tabPanel(
-                  "library(modules) stats",
-                  p("Example of using stats::lag function from library(modules) 'library_modules_lab_stats.R'"),
-                  p("Desired output: statslag(1:5)"),
-                  uiOutput("tab-3-modules-stats-lag-ui")
-                ),
-                tabPanel(
-                  "library(modules) dplyr",
-                  p("Example of using dplyr::lag function from library(modules) 'library_modules_lab_dplyr.R'"),
-                  p("Desired output: dplyr::lag(1:5)"),
-                  uiOutput("tab-3-modules-dplyr-lag-ui")
-                )
-              )
+            tabPanel(
+              "dplyr",
+              p("using 'lag_dplyr.R'"),
+              p("Desired output: dplyr::lag(1:5)"),
+              uiOutput("tab-3-mimick-modules-dplyr-lag-ui")
             )
           )
         )
@@ -77,34 +83,77 @@ list(
         box(
           title = "Load 3rd-party Shiny module",
           width = 12,
-          column(
-            width = 3, 
-            actionButton("tab-3-load-shiny-module-stats", label = "Load Shiny module using stats"),
-            hidden(p(id = "tab-3-load-shiny-module-stats-status", "loaded Shiny module 'lag' using library(stats)"))
+          fluidRow(
+            column(
+              width = 6, 
+              actionButton("tab-3-load-shiny-module-stats", label = "Load Shiny module using stats"),
+              hidden(p(id = "tab-3-load-shiny-module-stats-status", "loaded Shiny module 'lag' using library(stats)"))
+            ),
+            column(
+              width = 6, 
+              actionButton("tab-3-load-shiny-module-dplyr", label = "Load Shiny module using dplyr"),
+              hidden(p(id = "tab-3-load-shiny-module-dplyr-status", "loaded Shiny module 'lag' using library(dplyr)"))
+            )
           ),
-          column(
-            width = 3, 
-            actionButton("tab-3-load-shiny-module-dplyr", label = "Load Shiny module using dplyr"),
-            hidden(p(id = "tab-3-load-shiny-module-dplyr-status", "loaded Shiny module 'lag' using library(dplyr)"))
+          hr(),
+          fluidRow(          
+            column(
+              width = 6,
+              actionButton("tab-3-load-modules-stats", label = "Load libary(module) using stats"),
+              hidden(p(id = "tab-3-load-modules-stats-status", "loaded module 'stats_lag' using library(modules)"))
+            ),
+            column(
+              width = 6,
+              actionButton("tab-3-load-modules-dplyr", label = "Load libary(module) using dplyr"),
+              hidden(p(id = "tab-3-load-modules-dplyr-status", "loaded module 'dplyr_lag' using library(modules)"))
+            )
           ),
-          column(
-            width = 3,
-            actionButton("tab-3-load-modules-stats", label = "Load libary(module) using stats"),
-            hidden(p(id = "tab-3-load-modules-stats-status", "loaded module 'stats_lag' using library(modules)"))
+          hr(),
+          fluidRow(          
+            column(
+              width = 6,
+              actionButton("tab-3-load-mimick-modules-stats", label = "Load mimicked libary(module) using stats"),
+              hidden(p(id = "tab-3-load-mimick-modules-stats-status", "loaded mimicked module 'stats_lag' using library(modules)"))
+            ),
+            column(
+              width = 6,
+              actionButton("tab-3-load-mimick-modules-dplyr", label = "Load mimicked libary(module) using dplyr"),
+              hidden(p(id = "tab-3-load-mimick-modules-dplyr-status", "loaded mimicked module 'dplyr_lag' using library(modules)"))
+            )
           ),
-          column(
-            width = 3,
-            actionButton("tab-3-load-modules-dplyr", label = "Load libary(module) using dplyr"),
-            hidden(p(id = "tab-3-load-modules-dplyr-status", "loaded module 'dplyr_lag' using library(modules)"))
-          ),
-          column(
-            width = 12,
-            verbatimTextOutput("tab-3-packages-loaded")
+          hr(),
+          fluidRow(
+            column(
+              width = 8,
+              verbatimTextOutput("tab-3-packages-attached")
+            ),
+            column(
+              width = 4,
+              actionButton("tab-3-packages-unload-dplyr", label = "Unattach dplyr")
+            )
           )
         )
       )
     ),
   server = function(input, output, session) {
+    # packages ----
+    # packages attached module
+    packages_attached <- reactiveVal((.packages()))
+    
+    output$`tab-3-packages-attached` <- renderPrint({
+      list(
+        `Packages attached` = paste(packages_attached(),collapse = ", ")
+      )
+    })
+    
+    # package unload
+    observeEvent(input$`tab-3-packages-unload-dplyr`, {
+      if ("dplyr" %in% .packages()) {
+        detach(name = "package:dplyr", unload = TRUE)
+      }
+      packages_attached(.packages())
+    })
+    
     # stats::lag ----
     observe({
       input$`tab-3-stats-lag-func`
@@ -137,29 +186,15 @@ list(
       })
     })
     
-    # lag-copy ----
-    observeEvent(input$`tab-3-lag-copy-func`,{
-      output$`tab-3-lag-copy-res` <- renderPrint({
-        list(
-          `Called Time` = Sys.time(),
-          Output = lag(1:5)
-        )
-      })
-    })
-    
-    # packages loaded module
-    packages_loaded <- reactiveVal((.packages()))
-    
-    output$`tab-3-packages-loaded` <- renderPrint({
-      list(
-        `Packages Loaded` = paste(packages_loaded(),collapse = ", ")
-      )
-    })
     
     # shiny module stats ----
+    output$`tab-3-shiny-module-stats-lag-ui` <- renderUI({
+      p('Click on button below "Load Shiny modules using stats" to use this')
+    })
+    
     observeEvent(input$`tab-3-load-shiny-module-stats`, {
       source("modules/lag/lag_stats.R")
-      packages_loaded(.packages())
+      packages_attached(.packages())
       show("tab-3-load-shiny-module-stats-status")
       
       output$`tab-3-shiny-module-stats-lag-ui` <- renderUI({
@@ -172,9 +207,13 @@ list(
     })
     
     # shiny module dplyr ----
+    output$`tab-3-shiny-module-dplyr-lag-ui` <- renderUI({
+      p('Click on button below "Load Shiny module using dplyr" to use this')
+    })
+    
     observeEvent(input$`tab-3-load-shiny-module-dplyr`, {
       source("modules/lag/lag_dplyr.R")
-      packages_loaded(.packages())
+      packages_attached(.packages())
       show("tab-3-load-shiny-module-dplyr-status")
       
       output$`tab-3-shiny-module-dplyr-lag-ui` <- renderUI({
@@ -194,7 +233,7 @@ list(
     observeEvent(input$`tab-3-load-modules-stats`, {
       used_module <- modules::use("modules/lag/library_modules_lag_stats.R")
       
-      packages_loaded(.packages())
+      packages_attached(.packages())
       show("tab-3-load-modules-stats-status")
       
       output$`tab-3-modules-stats-lag-ui` <- renderUI({
@@ -214,7 +253,7 @@ list(
     observeEvent(input$`tab-3-load-modules-dplyr`, {
       used_module <- modules::use("modules/lag/library_modules_lag_dplyr.R")
       
-      packages_loaded(.packages())
+      packages_attached(.packages())
       show("tab-3-load-modules-dplyr-status")
       
       output$`tab-3-modules-dplyr-lag-ui` <- renderUI({
@@ -223,6 +262,46 @@ list(
       
       callModule(
         used_module$lagSERVER, "tab-3-modules-dplyr-lag"
+      )
+    })
+    
+    # mimicked library(modules) stats ----
+    output$`tab-3-mimick-modules-stats-lag-ui` <- renderUI({
+      p('Click on button below "Load mimicked library(modules) using stats" to use this')
+    })
+    
+    observeEvent(input$`tab-3-load-mimick-modules-stats`, {
+      used_module <- betweentwotests_use("modules/lag/library_modules_lag_stats.R")
+      
+      packages_attached(.packages())
+      show("tab-3-load-mimick-modules-stats-status")
+      
+      output$`tab-3-mimick-modules-stats-lag-ui` <- renderUI({
+        used_module$lagUI("tab-3-mimick-modules-stats-lag")
+      })
+      
+      callModule(
+        used_module$lagSERVER, "tab-3-mimick-modules-stats-lag"
+      )
+    })
+    
+    # mimicked library(modules) dplyr ----
+    output$`tab-3-mimick-modules-dplyr-lag-ui` <- renderUI({
+      p('Click on button below "Load mimicked library(modules) using dplyr" to use this')
+    })
+    
+    observeEvent(input$`tab-3-load-mimick-modules-dplyr`, {
+      used_module <- betweentwotests_use("modules/lag/library_modules_lag_dplyr.R")
+      
+      packages_attached(.packages())
+      show("tab-3-load-mimick-modules-dplyr-status")
+      
+      output$`tab-3-mimick-modules-dplyr-lag-ui` <- renderUI({
+        used_module$lagUI("tab-3-mimick-modules-dplyr-lag")
+      })
+      
+      callModule(
+        used_module$lagSERVER, "tab-3-mimick-modules-dplyr-lag"
       )
     })
   }

--- a/components/03_tab_3.R
+++ b/components/03_tab_3.R
@@ -271,7 +271,7 @@ list(
     })
     
     observeEvent(input$`tab-3-load-mimick-modules-stats`, {
-      used_module <- betweentwotests_use("modules/lag/lag_stats.R")
+      used_module <- modules_custom_use("modules/lag/lag_stats.R")
       
       packages_attached(.packages())
       show("tab-3-load-mimick-modules-stats-status")
@@ -291,7 +291,7 @@ list(
     })
     
     observeEvent(input$`tab-3-load-mimick-modules-dplyr`, {
-      used_module <- betweentwotests_use("modules/lag/lag_dplyr.R")
+      used_module <- modules_custom_use("modules/lag/lag_dplyr.R")
       
       packages_attached(.packages())
       show("tab-3-load-mimick-modules-dplyr-status")

--- a/components/03_tab_3.R
+++ b/components/03_tab_3.R
@@ -23,7 +23,7 @@ list(
             tabPanel(
               "stats",
               p("using 'library_modules_lab_stats.R'"),
-              p("Desired output: statslag(1:5)"),
+              p("Desired output: stats::lag(1:5)"),
               uiOutput("tab-3-modules-stats-lag-ui")
             ),
             tabPanel(
@@ -271,7 +271,7 @@ list(
     })
     
     observeEvent(input$`tab-3-load-mimick-modules-stats`, {
-      used_module <- betweentwotests_use("modules/lag/library_modules_lag_stats.R")
+      used_module <- betweentwotests_use("modules/lag/lag_stats.R")
       
       packages_attached(.packages())
       show("tab-3-load-mimick-modules-stats-status")
@@ -291,7 +291,7 @@ list(
     })
     
     observeEvent(input$`tab-3-load-mimick-modules-dplyr`, {
-      used_module <- betweentwotests_use("modules/lag/library_modules_lag_dplyr.R")
+      used_module <- betweentwotests_use("modules/lag/lag_dplyr.R")
       
       packages_attached(.packages())
       show("tab-3-load-mimick-modules-dplyr-status")

--- a/components/03_tab_3.R
+++ b/components/03_tab_3.R
@@ -23,7 +23,21 @@ list(
             column(
               width = 4,
               h4("Example of using lag function from Shiny module 'lag'"),
-              uiOutput("tab-3-shiny-module-lag-ui")
+              tabsetPanel(
+                tabPanel(
+                  "Shiny modules 'stats'",
+                  p("Example of using library(stats) lag function from 'lag_stats.R'"),
+                  p("Desired output: stats::lag(1:5)"),
+                  uiOutput("tab-3-shiny-module-stats-lag-ui")
+                ),
+                tabPanel(
+                  "Shiny modules 'dplyr'",
+                  p("Example of using library(dplyr) lag funciton from 'lag_dplyr.R'"),
+                  p("Desired output: dplyr::lag(1:5)"),
+                  uiOutput("tab-3-shiny-module-dplyr-lag-ui")
+                )
+              )
+              
             )
           ),
           fluidRow(
@@ -41,20 +55,20 @@ list(
             ),
             column(
               width = 4,
-              
               tabsetPanel(
                 tabPanel(
-                  "stats_modules",
-                  h4("Example of using stats::lag function from library(modules) 'stats_lag_modules.R'"),
+                  "library(modules) stats",
+                  p("Example of using stats::lag function from library(modules) 'library_modules_lab_stats.R'"),
+                  p("Desired output: statslag(1:5)"),
                   uiOutput("tab-3-modules-stats-lag-ui")
                 ),
                 tabPanel(
-                  "dplyr_modules",
-                  h4("Example of using dplyr::lag function from library(modules) 'dplyr_lag_modules.R'"),
+                  "library(modules) dplyr",
+                  p("Example of using dplyr::lag function from library(modules) 'library_modules_lab_dplyr.R'"),
+                  p("Desired output: dplyr::lag(1:5)"),
                   uiOutput("tab-3-modules-dplyr-lag-ui")
                 )
               )
-              
             )
           )
         )
@@ -65,8 +79,13 @@ list(
           width = 12,
           column(
             width = 3, 
-            actionButton("tab-3-load-shiny-module", label = "Load Shiny module"),
-            hidden(p(id = "tab-3-load-shiny-module-status", "loaded module 'lag' using library(shiny)"))
+            actionButton("tab-3-load-shiny-module-stats", label = "Load Shiny module using stats"),
+            hidden(p(id = "tab-3-load-shiny-module-stats-status", "loaded Shiny module 'lag' using library(stats)"))
+          ),
+          column(
+            width = 3, 
+            actionButton("tab-3-load-shiny-module-dplyr", label = "Load Shiny module using dplyr"),
+            hidden(p(id = "tab-3-load-shiny-module-dplyr-status", "loaded Shiny module 'lag' using library(dplyr)"))
           ),
           column(
             width = 3,
@@ -137,38 +156,33 @@ list(
       )
     })
     
-    # shiny-module ----
-    observeEvent(input$`tab-3-load-shiny-module`, {
-      source("modules/lag/lag.R")
+    # shiny module stats ----
+    observeEvent(input$`tab-3-load-shiny-module-stats`, {
+      source("modules/lag/lag_stats.R")
       packages_loaded(.packages())
-      show("tab-3-load-shiny-module-status")
+      show("tab-3-load-shiny-module-stats-status")
       
-      output$`tab-3-shiny-module-lag-ui` <- renderUI({
-        lagUI("tab-3-shiny-module-lag")
+      output$`tab-3-shiny-module-stats-lag-ui` <- renderUI({
+        lagUI("tab-3-shiny-module-stats-lag")
       })
       
       callModule(
-        lagSERVER, "tab-3-shiny-module-lag"
+        lagSERVER, "tab-3-shiny-module-stats-lag"
       )
     })
     
-    # library(modules) dplyr ----
-    output$`tab-3-modules-dplyr-lag-ui` <- renderUI({
-      p('Click on button below "Load library(modules) using dplyr" to use this')
-    })
-    
-    observeEvent(input$`tab-3-load-modules-dplyr`, {
-      used_module <- modules::use("modules/lag/dplyr_lag_modules.R")
-      
+    # shiny module dplyr ----
+    observeEvent(input$`tab-3-load-shiny-module-dplyr`, {
+      source("modules/lag/lag_dplyr.R")
       packages_loaded(.packages())
-      show("tab-3-load-modules-dplyr-status")
+      show("tab-3-load-shiny-module-dplyr-status")
       
-      output$`tab-3-modules-dplyr-lag-ui` <- renderUI({
-        used_module$lagUI("tab-3-modules-dplyr-lag")
+      output$`tab-3-shiny-module-dplyr-lag-ui` <- renderUI({
+        lagUI("tab-3-shiny-module-dplyr-lag")
       })
       
       callModule(
-        used_module$lagSERVER, "tab-3-modules-dplyr-lag"
+        lagSERVER, "tab-3-shiny-module-dplyr-lag"
       )
     })
     
@@ -178,7 +192,7 @@ list(
     })
     
     observeEvent(input$`tab-3-load-modules-stats`, {
-      used_module <- modules::use("modules/lag/stats_lag_modules.R")
+      used_module <- modules::use("modules/lag/library_modules_lag_stats.R")
       
       packages_loaded(.packages())
       show("tab-3-load-modules-stats-status")
@@ -189,6 +203,26 @@ list(
       
       callModule(
         used_module$lagSERVER, "tab-3-modules-stats-lag"
+      )
+    })
+    
+    # library(modules) dplyr ----
+    output$`tab-3-modules-dplyr-lag-ui` <- renderUI({
+      p('Click on button below "Load library(modules) using dplyr" to use this')
+    })
+    
+    observeEvent(input$`tab-3-load-modules-dplyr`, {
+      used_module <- modules::use("modules/lag/library_modules_lag_dplyr.R")
+      
+      packages_loaded(.packages())
+      show("tab-3-load-modules-dplyr-status")
+      
+      output$`tab-3-modules-dplyr-lag-ui` <- renderUI({
+        used_module$lagUI("tab-3-modules-dplyr-lag")
+      })
+      
+      callModule(
+        used_module$lagSERVER, "tab-3-modules-dplyr-lag"
       )
     })
   }

--- a/global.R
+++ b/global.R
@@ -36,9 +36,13 @@ betweentwotests_use <- function(file) {
   e$file <- file
   
   modules::module({
-    # Load base & friends
+    # Load base's friends
+    modules::import("methods")
+    modules::import("datasets")
+    modules::import("utils")
+    modules::import("grDevices")
+    modules::import("graphics")
     modules::import("stats")
-    # ... rest omitted for demo purpose
     
     # mask base::library
     library <- modules::import
@@ -47,12 +51,36 @@ betweentwotests_use <- function(file) {
   },topEncl = e)
 }
 
-# Test
+#' Improved version of betweentwotests_use() by wahani
+modules_custom_use <- function(file) {
+  modules::amodule({
+    # Load base's friends
+    modules::import("methods")
+    modules::import("datasets")
+    modules::import("utils")
+    modules::import("grDevices")
+    modules::import("graphics")
+    modules::import("stats")
+    
+    # mask base::library
+    library <- modules::import
+    
+    base::source(file, local = environment())
+  })
+}
+
+# # Test
 # module_filename <- "modules/lag/lag_stats.R"
 # wahani_m <- wahani_use(module_filename)
 # wahani_m$lagUI("test")       # Doesn't work; shiny::NS functions not found
 # wahani_m$lag_test()          # Doesn't work; stats::lag function not found
-#
+# 
 # betweentwotests_m <- betweentwotests_use(module_filename)
 # betweentwotests_m$lagUI("test")
 # betweentwotests_m$lag_test()
+# 
+# modules_custom_use_m <- modules_custom_use(module_filename)
+# modules_custom_use_m$lagUI("test")
+# modules_custom_use_m$lag_test()
+
+

--- a/global.R
+++ b/global.R
@@ -13,9 +13,46 @@ for (package in required_packages) {
 rm(package, required_packages)
 
 # Load Packages. The order of loading package is intentiontal. 
-library(modules)
+# library(modules)
 library(shiny)
 library(shinydashboard)
 library(shinyjs)
 
 # don't load library(dplyr)
+
+wahani_use <- function(file) {
+  ## - custom definition of modules::use to circumvent base::library
+  ## - use with care
+  ## - still throws a warning, which is expected
+  e <- new.env(parent = baseenv())
+  e$library <- modules::import
+  modules::as.module(file, topEncl = e)
+}
+
+betweentwotests_use <- function(file) {
+  # create base environment with module_filename
+  # because module_filename is determined by user input (app requirement)
+  e <- new.env(parent = baseenv())
+  e$file <- file
+  
+  modules::module({
+    # Load base & friends
+    modules::import("stats")
+    # ... rest omitted for demo purpose
+    
+    # mask base::library
+    library <- modules::import
+    
+    source(file, local=TRUE)
+  },topEncl = e)
+}
+
+# Test
+# module_filename <- "modules/lag/lag_stats.R"
+# wahani_m <- wahani_use(module_filename)
+# wahani_m$lagUI("test")       # Doesn't work; shiny::NS functions not found
+# wahani_m$lag_test()          # Doesn't work; stats::lag function not found
+#
+# betweentwotests_m <- betweentwotests_use(module_filename)
+# betweentwotests_m$lagUI("test")
+# betweentwotests_m$lag_test()

--- a/global.R
+++ b/global.R
@@ -10,7 +10,7 @@ for (package in required_packages) {
     install.packages(package)
   }
 }
-rm(package)
+rm(package, required_packages)
 
 # Load Packages. The order of loading package is intentiontal. 
 library(modules)

--- a/modules/lag/lag_dplyr.R
+++ b/modules/lag/lag_dplyr.R
@@ -1,0 +1,27 @@
+# Modules for calculating lag() using 'dplyr' package
+#   without specifying which package
+# Does not follows library(modules) rules
+
+library(shiny)
+library(dplyr)
+
+#' Module function returning UI code
+lagUI <- function(id) {
+  ns <- NS(id)
+  tagList(
+    actionButton(ns("func"), label = "lag(1:5)"),
+    verbatimTextOutput(ns("res"))
+  )
+}
+
+#' Module function containing SERVER code
+lagSERVER <- function(input, output, session) {
+  observeEvent(input$`func`,{
+    output$`res` <- renderPrint({
+      list(
+        `Called Time` = Sys.time(),
+        Output = lag(1:5) # <--- note that which package's verison of lag is not being specified
+      )
+    })
+  })
+}

--- a/modules/lag/lag_dplyr.R
+++ b/modules/lag/lag_dplyr.R
@@ -25,3 +25,8 @@ lagSERVER <- function(input, output, session) {
     })
   })
 }
+
+# For testing
+lag_test <- function() {
+  lag(1:5)
+}

--- a/modules/lag/lag_stats.R
+++ b/modules/lag/lag_stats.R
@@ -1,8 +1,9 @@
-# Modules for counting and displaying counts
-# using library(modules)
+# Modules for calculating lag() using 'stats' package
+#   without specifying which package
+# Does not follows library(modules) rules
 
-modules::import(shiny)
-modules::import(dplyr)
+library(shiny)
+
 
 #' Module function returning UI code
 lagUI <- function(id) {

--- a/modules/lag/lag_stats.R
+++ b/modules/lag/lag_stats.R
@@ -4,7 +4,6 @@
 
 library(shiny)
 
-
 #' Module function returning UI code
 lagUI <- function(id) {
   ns <- NS(id)
@@ -24,4 +23,9 @@ lagSERVER <- function(input, output, session) {
       )
     })
   })
+}
+
+# For testing
+lag_test <- function() {
+  lag(1:5)
 }

--- a/modules/lag/library_modules_lag_dplyr.R
+++ b/modules/lag/library_modules_lag_dplyr.R
@@ -1,6 +1,9 @@
-# Modules for counting and displaying counts
+# Modules for calculating lag() using 'dplyr' package
+#
+# Follows library(modules) rules
 
-library(dplyr)
+modules::import(shiny)
+modules::import(dplyr)
 
 #' Module function returning UI code
 lagUI <- function(id) {

--- a/modules/lag/library_modules_lag_stats.R
+++ b/modules/lag/library_modules_lag_stats.R
@@ -1,5 +1,6 @@
-# Modules for counting and displaying counts
-# using library(modules)
+# Modules for calculating lag() using 'stats' package
+#
+# Follows library(modules) rules
 
 modules::import(shiny)
 modules::import(stats)


### PR DESCRIPTION
Modifying your patch with what I think is the solution.

Your use() function (which I renamed to wahani_use() and is in `global.R`) doesn't seem to mask `library` function as I would like. See example in `global.R`.

I extended your helpful function to what I think I want `betweentwotests_use()`. I did not know how to attach a library to custom environment using base R functions, so I leverated the libarary(modules) features.

I am not sure why your wahani_use() did not work.

I want to know if my intent is clear here (Sorry if I am not explaining very well). Currently the app is showing what I would like. I am looking for feedback.

The goal is: `lag_stats.R` and `lag_dplyr.R` files are written by other people who do not know about library(modules). If their scripts (`lag_stats.R` or`lag_dplyr.R`) works in their R session, then they will hand over that script to me. I will then place them in to `modules` library. My goal is to use `library(modules)` to mimick their environment as much as possible (most importantly loaded package ordering). The app is showing exactly what I want at this time.

I am curious if betweentwotests_use() can be improved and added to be part of library(modules) (with better explanation of what it is doing and how it is different from exisiting modules::use()). I wonder if the helper functions in library(modules) can be used to replicate betweentwotests_use() 